### PR TITLE
Add external audio track loading and persistence

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,8 @@ import {
   getPosition,
   savePosition,
   clearPosition,
+  getAudioSelection,
+  saveAudioSelection,
   getPlaylistItem,
   savePlaylistItem,
   addRecent,
@@ -3443,6 +3445,15 @@ function startMpv(): void {
       pendingResumeToast = '' // clear any stale pending toast from a failed load
       loadedTarget = playlist[plIndex] || ''
       flushPendingSubs(loadedTarget) // Emby's sidecar subs, if the lookup beat the load
+      // Restore the viewer's per-file audio choice before seeking. An external
+      // track joins mpv's current timeline, so the following resume seek moves
+      // picture and both audio kinds to the same saved position.
+      const audio = resumePath ? getAudioSelection(resumePath) : undefined
+      if (audio?.type === 'embedded') {
+        mpv?.setProperty('aid', audio.id)
+      } else if (audio?.type === 'external' && existsSync(audio.path)) {
+        mpv?.command(['audio-add', audio.path, 'select']).catch(() => {})
+      }
       if (getSettings().resumePlayback && resumePath && canResume()) {
         const pos = getPosition(resumePath)
         if (typeof pos === 'number' && pos > 5) {
@@ -3636,6 +3647,18 @@ function registerIpc(): void {
   ipcMain.on('playlist:move', (_e, indices: number[], to: number) => movePlaylistItems(indices, to))
   ipcMain.on('playlist:remove-multi', (_e, indices: number[]) => removePlaylistItems(indices))
   ipcMain.on('playlist:repeat-cycle', () => cycleRepeat())
+  ipcMain.on('audio:select', (_e, id: number) => {
+    if (!Number.isInteger(id)) return
+    mpv?.setProperty('aid', id)
+    if (!resumePath) return
+    const track = lastTracks.find(t => t.type === 'audio' && t.id === id)
+    const externalPath = track?.['external-filename']
+    if (track?.external === true && typeof externalPath === 'string' && externalPath) {
+      saveAudioSelection(resumePath, { type: 'external', path: externalPath })
+    } else {
+      saveAudioSelection(resumePath, { type: 'embedded', id })
+    }
+  })
   ipcMain.on('audio:add', async () => {
     const res = await dialog.showOpenDialog(win!, {
       title: tr('dlg.addAudio'),
@@ -3656,6 +3679,9 @@ function registerIpc(): void {
         // mpv aligns an external track to the current playback timeline, so adding
         // it halfway through a video starts it at the matching position.
         await mpv?.command(['audio-add', res.filePaths[0], 'select'])
+        if (resumePath) {
+          saveAudioSelection(resumePath, { type: 'external', path: res.filePaths[0] })
+        }
       } catch {
         /* ignore */
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3636,6 +3636,31 @@ function registerIpc(): void {
   ipcMain.on('playlist:move', (_e, indices: number[], to: number) => movePlaylistItems(indices, to))
   ipcMain.on('playlist:remove-multi', (_e, indices: number[]) => removePlaylistItems(indices))
   ipcMain.on('playlist:repeat-cycle', () => cycleRepeat())
+  ipcMain.on('audio:add', async () => {
+    const res = await dialog.showOpenDialog(win!, {
+      title: tr('dlg.addAudio'),
+      properties: ['openFile'],
+      filters: [
+        {
+          name: tr('panel.sec.audio'),
+          extensions: [
+            'aac', 'ac3', 'dts', 'eac3', 'flac', 'm4a', 'mka', 'mp2', 'mp3',
+            'ogg', 'opus', 'thd', 'truehd', 'wav', 'w64', 'wv'
+          ]
+        },
+        { name: tr('dlg.filter.allFiles'), extensions: ['*'] }
+      ]
+    })
+    if (!res.canceled && res.filePaths[0]) {
+      try {
+        // mpv aligns an external track to the current playback timeline, so adding
+        // it halfway through a video starts it at the matching position.
+        await mpv?.command(['audio-add', res.filePaths[0], 'select'])
+      } catch {
+        /* ignore */
+      }
+    }
+  })
   ipcMain.on('sub:add', async () => {
     const res = await dialog.showOpenDialog(win!, {
       title: tr('dlg.addSubtitle'),

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -136,6 +136,51 @@ export function clearPosition(path: string): void {
   writePositions()
 }
 
+// ---- per-file selected audio track ----
+// Kept apart from resume positions: reaching the end clears a position, but must
+// not forget which embedded/external track the viewer chose for that file.
+export type AudioSelection =
+  | { type: 'embedded'; id: number }
+  | { type: 'external'; path: string }
+
+type AudioSelections = Record<string, AudioSelection>
+let audioCache: AudioSelections | null = null
+const audioFile = (): string => join(app.getPath('userData'), 'audio-selections.json')
+
+function audioSelections(): AudioSelections {
+  if (audioCache) return audioCache
+  try {
+    const parsed = JSON.parse(readFileSync(audioFile(), 'utf8')) as Record<string, unknown>
+    audioCache = Object.fromEntries(
+      Object.entries(parsed).filter((entry): entry is [string, AudioSelection] => {
+        const value = entry[1]
+        if (!value || typeof value !== 'object') return false
+        const selection = value as Record<string, unknown>
+        return (
+          (selection.type === 'embedded' && typeof selection.id === 'number') ||
+          (selection.type === 'external' && typeof selection.path === 'string')
+        )
+      })
+    )
+  } catch {
+    audioCache = {}
+  }
+  return audioCache!
+}
+
+export function getAudioSelection(path: string): AudioSelection | undefined {
+  return audioSelections()[path]
+}
+
+export function saveAudioSelection(path: string, selection: AudioSelection): void {
+  audioSelections()[path] = selection
+  try {
+    writeFileSync(audioFile(), JSON.stringify(audioSelections()))
+  } catch {
+    /* ignore */
+  }
+}
+
 // ---- per-playlist "last item" (which video in a URL playlist you got to) ----
 // Keyed by a stable playlist id (e.g. YouTube's list=…), value = that item's URL.
 // Combined with the per-file positions above, reopening a playlist resumes both

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -273,6 +273,7 @@ const api = {
   removePlaylistItems: (indices: number[]): void => ipcRenderer.send('playlist:remove-multi', indices),
   addToPlaylist: (): void => ipcRenderer.send('playlist:add'),
   cycleRepeat: (): void => ipcRenderer.send('playlist:repeat-cycle'),
+  addAudio: (): void => ipcRenderer.send('audio:add'),
   addSubtitle: (): void => ipcRenderer.send('sub:add'),
   onPlaylistChanged: (cb: (p: Playlist) => void): Unsubscribe =>
     subscribe('playlist:changed', (p: Playlist) => cb(p)),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -273,6 +273,7 @@ const api = {
   removePlaylistItems: (indices: number[]): void => ipcRenderer.send('playlist:remove-multi', indices),
   addToPlaylist: (): void => ipcRenderer.send('playlist:add'),
   cycleRepeat: (): void => ipcRenderer.send('playlist:repeat-cycle'),
+  selectAudio: (id: number): void => ipcRenderer.send('audio:select', id),
   addAudio: (): void => ipcRenderer.send('audio:add'),
   addSubtitle: (): void => ipcRenderer.send('sub:add'),
   onPlaylistChanged: (cb: (p: Playlist) => void): Unsubscribe =>

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -923,7 +923,7 @@ export default function RightPanel({ open, onClose }: { open: boolean; onClose: 
                 <div
                   key={`a${tk.id}`}
                   className={`pl-item ${tk.id === aid ? 'active' : ''}`}
-                  onClick={() => window.mmp.set('aid', tk.id)}
+                  onClick={() => window.mmp.selectAudio(tk.id)}
                 >
                   <span className="pl-mark">{tk.id === aid ? <Check /> : null}</span>
                   <span className="pl-name" onMouseEnter={e => clipTitle(e.currentTarget)}>

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -932,6 +932,12 @@ export default function RightPanel({ open, onClose }: { open: boolean; onClose: 
                 </div>
               ))
             )}
+            <button className="track-add" onClick={() => window.mmp.addAudio()}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              {t('panel.addAudio')}
+            </button>
             <AdjustRow
               label={t('adjust.delay')}
               variant="step"

--- a/src/shared/i18n/de.ts
+++ b/src/shared/i18n/de.ts
@@ -225,6 +225,7 @@ export const de: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': 'Untertitel',
   'panel.empty.audio': 'Keine Audiospuren',
   'panel.subNone': 'Keine',
+  'panel.addAudio': 'Audiospur hinzufügen…',
   'panel.addSub': 'Untertitel hinzufügen…',
   'panel.trackN': 'Spur {n}',
 
@@ -284,6 +285,7 @@ export const de: Partial<Record<Key, string>> = {
     'Der Ordner enthält {count} Videos — die ersten {max} werden geladen',
   'main.resumed': 'Fortgesetzt ab {time}',
   'dlg.selectFolder': 'Ordner wählen (Video-Ordner oder Blu-ray/DVD-Disc)',
+  'dlg.addAudio': 'Audiospur hinzufügen',
   'dlg.addSubtitle': 'Untertitel hinzufügen',
   'dlg.addToPlaylist': 'Zur Wiedergabeliste hinzufügen',
   'dlg.openMedia': 'Medium öffnen',

--- a/src/shared/i18n/en.ts
+++ b/src/shared/i18n/en.ts
@@ -291,6 +291,7 @@ export const en = {
   'panel.sec.subtitles': 'Subtitles',
   'panel.empty.audio': 'No audio tracks',
   'panel.subNone': 'None',
+  'panel.addAudio': 'Add audio…',
   'panel.addSub': 'Add subtitle…',
   'panel.trackN': 'Track {n}',
 
@@ -359,6 +360,7 @@ export const en = {
   'main.folderTruncated': 'Folder has {count} videos — loading the first {max}',
   'main.resumed': 'Resumed from {time}',
   'dlg.selectFolder': 'Select a folder (a video folder, or a Blu-ray/DVD disc)',
+  'dlg.addAudio': 'Add Audio',
   'dlg.addSubtitle': 'Add Subtitle',
   'dlg.addToPlaylist': 'Add to Playlist',
   'dlg.openMedia': 'Open Media',

--- a/src/shared/i18n/es.ts
+++ b/src/shared/i18n/es.ts
@@ -225,6 +225,7 @@ export const es: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': 'Subtítulos',
   'panel.empty.audio': 'Sin pistas de audio',
   'panel.subNone': 'Ninguno',
+  'panel.addAudio': 'Añadir pista de audio…',
   'panel.addSub': 'Añadir subtítulo…',
   'panel.trackN': 'Pista {n}',
 
@@ -284,6 +285,7 @@ export const es: Partial<Record<Key, string>> = {
     'La carpeta tiene {count} vídeos — cargando los primeros {max}',
   'main.resumed': 'Reanudado desde {time}',
   'dlg.selectFolder': 'Selecciona una carpeta (carpeta de vídeo o disco Blu-ray/DVD)',
+  'dlg.addAudio': 'Añadir pista de audio',
   'dlg.addSubtitle': 'Añadir subtítulo',
   'dlg.addToPlaylist': 'Añadir a la lista de reproducción',
   'dlg.openMedia': 'Abrir medio',

--- a/src/shared/i18n/fr.ts
+++ b/src/shared/i18n/fr.ts
@@ -225,6 +225,7 @@ export const fr: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': 'Sous-titres',
   'panel.empty.audio': 'Aucune piste audio',
   'panel.subNone': 'Aucun',
+  'panel.addAudio': 'Ajouter une piste audio…',
   'panel.addSub': 'Ajouter un sous-titre…',
   'panel.trackN': 'Piste {n}',
 
@@ -284,6 +285,7 @@ export const fr: Partial<Record<Key, string>> = {
     'Le dossier contient {count} vidéos — chargement des {max} premières',
   'main.resumed': 'Repris à {time}',
   'dlg.selectFolder': 'Sélectionner un dossier (dossier vidéo, ou disque Blu-ray/DVD)',
+  'dlg.addAudio': 'Ajouter une piste audio',
   'dlg.addSubtitle': 'Ajouter un sous-titre',
   'dlg.addToPlaylist': 'Ajouter à la liste de lecture',
   'dlg.openMedia': 'Ouvrir un média',

--- a/src/shared/i18n/ja.ts
+++ b/src/shared/i18n/ja.ts
@@ -227,6 +227,7 @@ export const ja: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': '字幕',
   'panel.empty.audio': '音声トラックなし',
   'panel.subNone': 'なし',
+  'panel.addAudio': '音声を追加…',
   'panel.addSub': '字幕を追加…',
   'panel.trackN': 'トラック {n}',
 
@@ -286,6 +287,7 @@ export const ja: Partial<Record<Key, string>> = {
     'フォルダーに {count} 本の動画 — 先頭 {max} 本を読み込みます',
   'main.resumed': '{time} から再開しました',
   'dlg.selectFolder': 'フォルダーを選択（動画フォルダー、または Blu-ray/DVD ディスク）',
+  'dlg.addAudio': '音声を追加',
   'dlg.addSubtitle': '字幕を追加',
   'dlg.addToPlaylist': 'プレイリストに追加',
   'dlg.openMedia': 'メディアを開く',

--- a/src/shared/i18n/ko.ts
+++ b/src/shared/i18n/ko.ts
@@ -227,6 +227,7 @@ export const ko: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': '자막',
   'panel.empty.audio': '오디오 트랙 없음',
   'panel.subNone': '없음',
+  'panel.addAudio': '오디오 추가…',
   'panel.addSub': '자막 추가…',
   'panel.trackN': '트랙 {n}',
 
@@ -286,6 +287,7 @@ export const ko: Partial<Record<Key, string>> = {
     '폴더에 동영상 {count}개 — 처음 {max}개를 로드합니다',
   'main.resumed': '{time}부터 이어서 재생',
   'dlg.selectFolder': '폴더 선택(동영상 폴더 또는 Blu-ray/DVD 디스크)',
+  'dlg.addAudio': '오디오 추가',
   'dlg.addSubtitle': '자막 추가',
   'dlg.addToPlaylist': '재생목록에 추가',
   'dlg.openMedia': '미디어 열기',

--- a/src/shared/i18n/pt.ts
+++ b/src/shared/i18n/pt.ts
@@ -225,6 +225,7 @@ export const pt: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': 'Legendas',
   'panel.empty.audio': 'Sem faixas de áudio',
   'panel.subNone': 'Nenhuma',
+  'panel.addAudio': 'Adicionar faixa de áudio…',
   'panel.addSub': 'Adicionar legenda…',
   'panel.trackN': 'Faixa {n}',
 
@@ -284,6 +285,7 @@ export const pt: Partial<Record<Key, string>> = {
     'A pasta tem {count} vídeos — a carregar os primeiros {max}',
   'main.resumed': 'Retomado a partir de {time}',
   'dlg.selectFolder': 'Selecione uma pasta (pasta de vídeo ou disco Blu-ray/DVD)',
+  'dlg.addAudio': 'Adicionar faixa de áudio',
   'dlg.addSubtitle': 'Adicionar legenda',
   'dlg.addToPlaylist': 'Adicionar à lista de reprodução',
   'dlg.openMedia': 'Abrir media',

--- a/src/shared/i18n/ru.ts
+++ b/src/shared/i18n/ru.ts
@@ -226,6 +226,7 @@ export const ru: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': 'Субтитры',
   'panel.empty.audio': 'Нет аудиодорожек',
   'panel.subNone': 'Нет',
+  'panel.addAudio': 'Добавить аудиодорожку…',
   'panel.addSub': 'Добавить субтитры…',
   'panel.trackN': 'Дорожка {n}',
 
@@ -285,6 +286,7 @@ export const ru: Partial<Record<Key, string>> = {
     'В папке {count} видео — загружаются первые {max}',
   'main.resumed': 'Продолжено с {time}',
   'dlg.selectFolder': 'Выберите папку (папку с видео или диск Blu-ray/DVD)',
+  'dlg.addAudio': 'Добавить аудиодорожку',
   'dlg.addSubtitle': 'Добавить субтитры',
   'dlg.addToPlaylist': 'Добавить в плейлист',
   'dlg.openMedia': 'Открыть медиа',

--- a/src/shared/i18n/zh-CN.ts
+++ b/src/shared/i18n/zh-CN.ts
@@ -221,6 +221,7 @@ export const zhCN: Partial<Record<Key, string>> = {
   'panel.sec.subtitles': '字幕',
   'panel.empty.audio': '无音轨',
   'panel.subNone': '无',
+  'panel.addAudio': '添加音轨…',
   'panel.addSub': '添加字幕…',
   'panel.trackN': '轨道 {n}',
 
@@ -283,6 +284,7 @@ export const zhCN: Partial<Record<Key, string>> = {
   'main.folderTruncated': '文件夹内有 {count} 个视频 — 仅加载前 {max} 个',
   'main.resumed': '已从 {time} 继续播放',
   'dlg.selectFolder': '选择文件夹（视频文件夹，或蓝光 / DVD 原盘）',
+  'dlg.addAudio': '添加音轨',
   'dlg.addSubtitle': '添加字幕',
   'dlg.addToPlaylist': '添加到播放列表',
   'dlg.openMedia': '打开媒体',


### PR DESCRIPTION
## Summary

- add an **Add audio...** action alongside external subtitle loading
- load and select external audio tracks without interrupting the current playback position
- remember the selected embedded or external audio track per media file
- restore the saved audio selection before applying the resume seek
- keep audio selections separate from resume positions so finishing a video does not forget its track

## Testing

- `npm run build`
- manually verified adding external audio during playback and reopening the video
- manually verified switching between embedded tracks and restoring the selected track